### PR TITLE
I've configured Vite for GitHub Pages deployment. This commit adds a …

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [react()],
+  base: '/tim-harmar-legal-website/',
+})


### PR DESCRIPTION
…`vite.config.js` file and sets the `base` option to the repository name. This will ensure that asset paths are correct when the site is deployed to a sub-directory on GitHub Pages, which should fix the blank page issue.