### PR TITLE
I've added a `homepage` field to `package.json`. This should fix the …

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "homepage": "https://harmart1.github.io/TH_Site/",
   "name": "tim-harmar-legal-website",
   "private": true,
   "version": "1.0.0",


### PR DESCRIPTION
…blank page issue you were seeing by making sure that asset paths are resolved correctly when the site is deployed to GitHub Pages.