### PR TITLE
feat: Use relative paths for assets to fix deployment

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -4,7 +4,7 @@ import react from '@vitejs/plugin-react'
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
-  base: '/TH_Site/',
+  base: './',
   build: {
     // Explicitly disable Server-Side Rendering
     ssr: false,


### PR DESCRIPTION
This commit changes the `base` setting in `vite.config.js` from an absolute path (`'/TH_Site/'`) to a relative path (`'./'`).

This change ensures that all asset paths in the generated `index.html` are relative to the file itself. This makes the build output portable and fixes issues where the application would not load its assets (resulting in a blank page) when deployed to a subdirectory on a static hosting service like GitHub Pages.