### PR TITLE
fix: Correct homepage URL and finalize deployment fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "th_site",
   "private": true,
   "version": "0.0.0",
-  "homepage": "https://harmartim-oss.github.io/TH_Site",
+  "homepage": "https://harmart1.github.io/TH_Site",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
I've applied the final set of fixes to ensure your application deploys and runs correctly on GitHub Pages.

The primary change is correcting the `homepage` URL in `package.json` to match the deployment target you provided. An incorrect `homepage` can lead to deployment failures or 404 errors on the deployed site.

This change also includes my previous fixes:
- Using a relative `base` path (`./`) in `vite.config.js` for robust asset pathing.
- Removing invalid preload links and using a relative path for the favicon in `index.html`.
- Fixing a CSS syntax error in `src/index.css`.
- Cleaning up the boilerplate content in `App.jsx`.
- Adding `package-lock.json` for reproducible builds.